### PR TITLE
Improve minimal style

### DIFF
--- a/assets/css/backend-style.css
+++ b/assets/css/backend-style.css
@@ -1,3 +1,40 @@
+/* Minimal admin styles */
+body {
+    font-family: "Segoe UI", Tahoma, sans-serif;
+    background-color: #f7f7f7;
+    color: #333;
+    margin: 0;
+    padding: 0;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    padding: 10px;
+    border: 1px solid #ddd;
+}
+
+th {
+    background-color: #f0f0f0;
+}
+
+button,
+input[type="submit"] {
+    background-color: #008cba;
+    color: #fff;
+    border: none;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover,
+input[type="submit"]:hover {
+    background-color: #007299;
+}
 /* margin from top in wallet , users and tikets */
 table.alternates{
     margin-top: 15px;

--- a/assets/css/forntend-style.css
+++ b/assets/css/forntend-style.css
@@ -1,3 +1,49 @@
+/* Minimal base styles */
+body {
+    font-family: "Segoe UI", Tahoma, sans-serif;
+    background-color: #f7f7f7;
+    color: #333;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+form {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+input[type="text"],
+input[type="password"],
+input[type="email"],
+textarea {
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.form-submit {
+    background-color: #008cba;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.form-submit:hover {
+    background-color: #007299;
+}
 #fname,#lname,#email,#pass,#emailin,#passin,#signin,#signup{
     margin: 5px;
 }

--- a/forntend/account/theme/login.php
+++ b/forntend/account/theme/login.php
@@ -5,7 +5,7 @@ if($current_user_id == 0){
 
 ?>
 <center>
-<div class="sign_in_w" style="padding: 10px;display:inline-block;">
+<div class="sign_in_w container">
 <h2 class="form-title">ورود</h2><br>
 <form method="POST" class="register-form" id="login_form">
 <div class="form-group">

--- a/forntend/account/theme/signup.php
+++ b/forntend/account/theme/signup.php
@@ -6,7 +6,7 @@
 <center>
 <?php if (get_option('users_can_register',[]) == 1) {
 ?>
-<div class="sign_up_w" style="padding: 10px;display:inline-block;">
+<div class="sign_up_w container">
     <h2 class="form-title">ثبت نام</h2><br>
     <form method="POST" class="register-form" id="register_form">
     <div class="form-group">


### PR DESCRIPTION
## Summary
- apply a minimal design for frontend and backend stylesheets
- remove inline style usage from login and signup templates

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593f5207008323b3a71b3e1e45a708